### PR TITLE
Fix for inputs with non-empty value attribute.

### DIFF
--- a/jquery.placeholder.js
+++ b/jquery.placeholder.js
@@ -31,7 +31,8 @@
 					var tagName = this.tagName.toLowerCase();
 					if (tagName === 'input' || tagName === 'textarea') {
 						var text = $(this).attr('placeholder') || '';
-						if (text.length) {
+						var value = $(this).val();
+						if (text.length && !value) {
 							var $placeholder = $('<span>').addClass('placeholder').html(text);
 							
 							// clear existing placeholder


### PR DESCRIPTION
For inputs with non-empty value placeholder displayed on top of the text.
Input example: <input id="Name" type="text" value="123"/>
