### PR TITLE
Placeholder span positioning fix + span show/hide behavior

### DIFF
--- a/jquery.placeholder.js
+++ b/jquery.placeholder.js
@@ -55,6 +55,8 @@
 								'cursor': $input.css('cursor') || 'text',
 								'display': 'block',
 								'position': 'absolute',
+								'top' : 0,
+								'left' : 0,
 								'overflow': 'hidden',
 								'z-index': zIndex + 1,
 								'background': 'none',
@@ -68,12 +70,13 @@
 								'border-left-color': 'transparent'
 							});
 							
-                            $placeholder.appendTo($('body'));
-							
-							// position span above the input
-							var inputOffset=$input.offset();
-							$placeholder.css('left', inputOffset.left);
-							$placeholder.css('top', inputOffset.top);
+							// position span above the input, using a wrapper div
+							$wrap=$('<div></div>');
+							$wrap.css('position','relative');
+							$wrap.css('display',$input.css('display'));
+							$input.wrap($wrap);
+							$placeholder.insertAfter($input);
+							$placeholder.height($input.height());
 							
 							// show / hide
 							$placeholder.on('mousedown', function() {

--- a/jquery.placeholder.js
+++ b/jquery.placeholder.js
@@ -81,15 +81,20 @@
 									$input.trigger('focus');
 								}, 0);
 							});
-							$input.on('focus.placeholder', function() {
-								$placeholder.hide();
+							//I don't need to hide the placeholder on focus, so this event is commented out
+//							$input.on('focus.placeholder', function() {
+//								$placeholder.hide();
+//							});
+							$input.on('keydown.placeholder', function() {
+								if ($.trim($input.val()).length) $placeholder.hide();
+								else $placeholder.show();
 							});
 							$input.on('blur.placeholder', function() {
 								$placeholder.toggle(!$.trim($input.val()).length);
 							});
 							input.onpropertychange = function() {
 								if (event.propertyName === 'value') {
-									$input.trigger('focus.placeholder');
+									$input.trigger('keydown.placeholder');
 								}
 							};
 							$input.trigger('blur.placeholder');

--- a/jquery.placeholder.js
+++ b/jquery.placeholder.js
@@ -68,13 +68,12 @@
 								'border-left-color': 'transparent'
 							});
 							
-							$placeholder.insertBefore($input);
+                            $placeholder.appendTo($('body'));
 							
-							// compensate for y difference caused by absolute / relative difference (line-height factor)
-							var dy = $input.offset().top - $placeholder.offset().top;
-							var marginTop = parseInt($placeholder.css('margin-top'));
-							if (isNaN(marginTop)) marginTop = 0;
-							$placeholder.css('margin-top', marginTop + dy);
+							// position span above the input
+							var inputOffset=$input.offset();
+							$placeholder.css('left', inputOffset.left);
+							$placeholder.css('top', inputOffset.top);
 							
 							// show / hide
 							$placeholder.on('mousedown', function() {


### PR DESCRIPTION
Thanks for this neat jQuery plugin.

I discovered a small issue under IE. You position the created span tag only on the Y axis, so you presume that the span is placed under the input, but it's not the case every time.
I just made a small modification to the code, to place the span directly under the document root and use the input tag offset position to place it.

The second commit changes the span show/hide behavior to mimic webkit. I just replaced the hide-on-focus to hide-on-value-change and added an extra check to show the placeholder when the user deletes the value of the input.
