### PR TITLE
Issue #9 : Focus should not be called on a disabled input

### DIFF
--- a/jquery.placeholder.js
+++ b/jquery.placeholder.js
@@ -78,9 +78,11 @@
 							
 							// show / hide
 							$placeholder.on('mousedown', function() {
-								window.setTimeout(function(){
-									$input.trigger('focus');
-								}, 0);
+								if($input.is(':enabled')) {
+									window.setTimeout(function(){
+										$input.trigger('focus');
+									}, 0);
+								}
 							});
 							$input.on('focus.placeholder', function() {
 								$placeholder.hide();


### PR DESCRIPTION
In IE8, an error will occur if focus is called on a disabled input.

(See issue #9)
