### PR TITLE
Toggle placeholder directly rather than using focus event

### DIFF
--- a/jquery.placeholder.js
+++ b/jquery.placeholder.js
@@ -88,16 +88,20 @@
 			}, 0);
 		});
 
+		function togglePlaceholderForInput() {
+			$placeholder.toggle(!$.trim($input.val()).length);
+		}
+
 		$input.on('focus.placeholder', function() {
 			$placeholder.hide();
 		});
 		$input.on('blur.placeholder', function() {
-			$placeholder.toggle(!$.trim($input.val()).length);
+			togglePlaceholderForInput();
 		});
 
 		$input[0].onpropertychange = function() {
 			if (event.propertyName === 'value') {
-				$input.trigger('focus.placeholder');
+				togglePlaceholderForInput();
 			}
 		};
 


### PR DESCRIPTION
Extract function to toggle placeholder explicitly rather than generating a focus event for toggle which may have other unwanted consequences.

Using focus can interfere with other controls that rely on that event. e.g. a date-picker popup on focus could be triggered unintentionally.
