### PR TITLE
Fix placeholder positioned incorrectly

### DIFF
--- a/jquery.placeholder.js
+++ b/jquery.placeholder.js
@@ -77,6 +77,11 @@
 		$placeholder.css('margin-top', marginTop + dy);
 		
 		$placeholder.css('left', $input.position().left);
+		
+		$(window).on('resize', function () {
+            		$placeholder.css('left', $input.position().left);
+		});
+
 
 		// event handlers + add to document
 		$placeholder.on('mousedown', function() {

--- a/jquery.placeholder.js
+++ b/jquery.placeholder.js
@@ -75,6 +75,8 @@
 		marginTop = parseInt($placeholder.css('margin-top'));
 		if (isNaN(marginTop)) marginTop = 0;
 		$placeholder.css('margin-top', marginTop + dy);
+		
+		$placeholder.css('left', $input.position().left);
 
 		// event handlers + add to document
 		$placeholder.on('mousedown', function() {


### PR DESCRIPTION
If two input fields positioned next to each other separated by a space - the placeholders are both placed in the first box.
