### PR TITLE
Filter `textarea`/`input` selection w/ `placeholder` attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 A basic jQuery plugin that reads the [**"placeholder"** attribute](http://www.w3schools.com/html5/att_input_placeholder.asp) (HTML5) and renders the placeholder text as an overlay (if not natively supported). Unlike most other plugins, this works by adding a properly-positioned `<span>` on top of the input element rather than setting its value. This keeps form serialization & validation from breaking. 
 
 ```javascript
-$('input,textarea').placeholder();
+$('input[placeholder], textarea[placeholder]').placeholder();
 ```
 
 Check out the [demos](http://diy.github.com/jquery-placeholder/)!


### PR DESCRIPTION
Filtering down the number of elements selected in your example code snippet by only selecting `textarea`/`input` elements that actually have a `placeholder` attribute.
