### PR TITLE
Updated link to placeholder description

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # .placeholder()
 
-A basic jQuery plugin that reads the [**"placeholder"** attribute](http://www.w3schools.com/html5/att_input_placeholder.asp) (HTML5) and renders the placeholder text as an overlay (if not natively supported). Unlike most other plugins, this works by adding a properly-positioned `<span>` on top of the input element rather than setting its value. This keeps form serialization & validation from breaking. 
+A basic jQuery plugin that reads the [**"placeholder"** attribute](http://www.w3.org/community/webed/wiki/HTML5_form_additions#placeholder) (HTML5) and renders the placeholder text as an overlay (if not natively supported). Unlike most other plugins, this works by adding a properly-positioned `<span>` on top of the input element rather than setting its value. This keeps form serialization & validation from breaking. 
 
 ```javascript
 $('input,textarea').placeholder();


### PR DESCRIPTION
I feel the wiki on w3c is better than w3schools content.
Reason: [w3fools](http://www.w3fools.com/)
