### PR TITLE
Fixed an issue with incorrect left alignment of the placeholder text

### DIFF
--- a/jquery.placeholder.js
+++ b/jquery.placeholder.js
@@ -27,7 +27,7 @@
 	];
 
 	var setupPlaceholder = function(input, options) {
-		var i, evt, text, styles, zIndex, marginTop, dy, attrNode;
+		var i, text, styles, zIndex, marginTop, dy, marginLeft, dx, attrNode;
 		var $input = $(input), $placeholder;
 
 		try {
@@ -75,6 +75,12 @@
 		marginTop = parseInt($placeholder.css('margin-top'));
 		if (isNaN(marginTop)) marginTop = 0;
 		$placeholder.css('margin-top', marginTop + dy);
+
+		// compensate for x difference caused by absolute / relative difference
+		dx = $input.offset().left - $placeholder.offset().left;
+		marginLeft = parseInt($placeholder.css('margin-left'));
+		if (isNaN(marginLeft)) marginLeft = 0;
+		$placeholder.css('margin-left', marginLeft + dx);
 
 		// event handlers + add to document
 		$placeholder.on('mousedown', function() {


### PR DESCRIPTION
There's an issue with incorrect left alignment of the placeholder in certain conditions.
You can see an example of the issue at: http://codepen.io/anon/pen/xdFib
In the example notice that the placeholder text is to the left of the input field overriding other elements.
![before](https://cloud.githubusercontent.com/assets/4381579/4873226/1b458fd4-6207-11e4-9519-309a6635ab19.png)

The fix was to add compensation for x difference like you have for the y difference.
You can see the result of applying the fix to the example at:
http://codepen.io/anon/pen/numxC
The placeholder text is now correctly placed in the the input field.
![after](https://cloud.githubusercontent.com/assets/4381579/4873230/43a4ca62-6207-11e4-8bf1-0273c1efcc3a.png)
