### PR TITLE
Fixed toggle function ignoring whitespace

### DIFF
--- a/jquery.placeholder.js
+++ b/jquery.placeholder.js
@@ -85,7 +85,7 @@
 		});
 
 		function togglePlaceholderForInput() {
-			$placeholder.toggle(!$.trim($input.val()).length);
+			$placeholder.toggle(!$input.val().length);
 		}
 
 		$input.on('focus.placeholder', function() {


### PR DESCRIPTION
The togglePlaceholderForInput function decides wether to display or hide the placeholder by trimming the input value and checking it's length. If it's 0 the placeholder is displayed, otherwise it's hidden.
The issue here is that by trimming the value, we can confuse the user because we ignore the actual value. For example if the value is a bunch of spaces, we will show the placeholder like there's noting there, even
though the user might be able to submit it.

If whitespace is not a valid value, then the developer should use some validation mechanism to prevent it from being submitted and alert the user. It shouldn't be the responsibility of a placeholder plugin.

Here's a Codepen without the fix with an initial value made up of spaces (click on "Submit" to see what I mean):
http://codepen.io/anon/pen/bJBtL
And here's a Codepen with the fix (with the same initial value):
http://codepen.io/anon/pen/kDABj
