### PR TITLE
New feature: add support for stay on focus

### DIFF
--- a/jquery.placeholder.js
+++ b/jquery.placeholder.js
@@ -87,22 +87,43 @@
 		function togglePlaceholderForInput() {
 			$placeholder.toggle(!$.trim($input.val()).length);
 		}
-
-		$input.on('focus.placeholder', function() {
-			$placeholder.hide();
-		});
-		$input.on('blur.placeholder', function() {
+		
+		if (options.stayOnFocus) {
+		    /**
+		     * We register to listen to several events that might cause a text change. When the event fires we test if
+		     * we need to show the placeholder or hide it. Some events might be redundant in certain browsers or
+		     * scenarios, but that's to be expected and in any case it shouldn't hurt performance. Highlights:
+		     * - keydown: we need to hide the placeholder when a key is pressed
+		     * - keyup: when we release the key we need to see how the value changed
+		     * - input: this event is similar to keyup, but we need to us it to catch clicks on the clear button ('X')
+		     * that IE adds to every input
+		     */
+		    $input.on('keydown.placeholder keyup.placeholder input.placeholder paste.placeholder cut.placeholder', function () {
 			togglePlaceholderForInput();
+		    });
+
+		} else {
+		    $input.on('focus.placeholder', function () {
+			$placeholder.hide();
+		    });
+		}
+
+		$input.on('blur.placeholder', function () {
+		    togglePlaceholderForInput();
 		});
 
-		$input[0].onpropertychange = function() {
-			if (event.propertyName === 'value') {
-				togglePlaceholderForInput();
-			}
+		$input[0].onpropertychange = function () {
+		    if (event.propertyName === 'value') {
+			togglePlaceholderForInput();
+		    }
 		};
 
-		$input.trigger('blur.placeholder');
-	};
+		if (options.stayOnFocus) {
+		    togglePlaceholderForInput();
+		} else {
+		    $input.trigger('blur.placeholder');
+		}
+	    };
 
 	// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 


### PR DESCRIPTION
The native placeholder behavior of current versions of Chrome and Firefox is to stay on focus until the user enters a value. This makes sense because a lot of developers are using placeholders in order to
instruct the user what to enter in the field. So while the field is in focus, but no value was entered, the instructions should still be displayed.
The way that the placeholder plugin currently works, the placeholder is hidden on focus.

I wanted to have the new behavior so I added support for it.

To use it you need to initialize placeholder with the "stayOnFocus" option set to true. Here's an example call:
`$('input[placeholder], textarea[placeholder]').placeholder({force: true, stayOnFocus: true});`
If you don't pass the new option (or you pass stayOnFocus=false) the behavior will remain as it was before (placeholder is hidden on focus). You can call it with or without force=true depending on if you want to replace the native browser behavior. For my project I set both force and stayOnFocus to true, because I wanted consistent behavior a cross all browsers.

To see an example of the old behavior, take a look at:
http://codepen.io/anon/pen/lnkhd
To see the new behavior (stayOnFocus=true), take a look at:
http://codepen.io/anon/pen/cDAjl
